### PR TITLE
feat: Eliminate `github-token` option

### DIFF
--- a/.github/workflows/ci-check-and-label.yaml
+++ b/.github/workflows/ci-check-and-label.yaml
@@ -19,27 +19,3 @@ jobs:
         with:
           include-pull-request-title: true
           allowed-commit-types: "fix,feat,chore,docs,refactor"
-
-  assign-labels:
-    name: Assign labels
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v5
-      - uses: mauroalderete/action-assign-labels@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          conventional-commits: |
-            conventional-commits:
-              - type: 'fix'
-                nouns: ['FIX', 'Fix', 'fix']
-                labels: ['bug']
-              - type: 'feature'
-                nouns: ['FEAT', 'Feat', 'feat']
-                labels: ['feature']
-              - type: 'chore'
-                nouns: ['CHORE', 'Chore', 'chore']
-                labels: ['chore']
-              - type: 'docs'
-                nouns: ['DOCS', 'Docs', 'docs']
-                labels: ['documentation']

--- a/.github/workflows/ci-check-and-label.yaml
+++ b/.github/workflows/ci-check-and-label.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: doomspork/actions-conventional-commits@latest
         with:
           include-pull-request-title: true
-          allowed-commit-types: "fix,feat,chore,docs"
+          allowed-commit-types: "fix,feat,chore,docs,refactor"
 
   assign-labels:
     name: Assign labels

--- a/.github/workflows/ci-check-and-label.yaml
+++ b/.github/workflows/ci-check-and-label.yaml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: doomspork/actions-conventional-commits@latest
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           include-pull-request-title: true
           allowed-commit-types: "fix,feat,chore,docs"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ jobs:
 
       - uses: doomspork/actions-conventional-commits@v1.4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }} # Optional, for private repositories.
           allowed-commit-types: "feat,fix" # Optional, set if you want a subset of commit types to be allowed.
           include-pull-request-title: true # Optional, set if you want to validate the pull request title.
           include-commits: false # Optional, set to false if you want to ignore commit messages.

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,6 @@
 name: "Conventional Commits"
 description: "Ensures that all commit messages are following the conventional-commits standard."
 inputs:
-  github-token:
-    description: "GitHub token"
-    required: false
   allowed-commit-types:
     description: "Specify a comma separated list of allowed commit types"
     default: "build,chore,ci,docs,feat,fix,merge,perf,refactor,revert,style,test,wip"

--- a/src/extractCommits.ts
+++ b/src/extractCommits.ts
@@ -20,7 +20,6 @@ const extractCommits = async (context: Context): Promise<Commit[]> => {
     try {
       const requestHeaders = {
         accept: "application/vnd.github+json",
-        authorization: `token ${core.getInput("github-token")}`,
       };
 
       const response = await ky


### PR DESCRIPTION
We're not actually using this so let's be more security minded and eliminate this. No reason anyone should pass this in if it isn't needed or used.

Tested removing the `github-token` option in private repo and it worked just fine.